### PR TITLE
Wavelet transform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ resources:
 # TODO: remove everything except for .gitignore
 test_cwt:
 	rm -rf ./sim_build/*
-	iverilog -DCOCOTB_SIM -o sim_build/sim.vvp  -s wavelet_transform -g2012 src/wavelet_transform.v  src/fir.v src/shift_register_line.v
+	iverilog -DCOCOTB_SIM -o sim_build/sim.vvp  -s wavelet_transform -g2012 src/wavelet_transform.v  src/fir.v src/shift_register_line.v src/output_multiplexer.v
 	PYTHONOPTIMIZE=${NOASSERT} MODULE=test.test_cwt vvp -M $$(cocotb-config --prefix)/cocotb/libs -m libcocotbvpi_icarus sim_build/sim.vvp
 
 

--- a/src/fir.v
+++ b/src/fir.v
@@ -1,15 +1,20 @@
 `default_nettype none
 `define M_T 6.2831853071
 
-// TODO: Assume SUM_TRUNCATION of 8 for now, but make this a parameter later
+// TODO: Hardcode for 8 bit input
+// TODO: calculate max bits from actual fir values instead of max, this may not be possible without using sv, or python and hardcoding it. */
 module fir #(
     parameter BITS_PER_ELEM = 8,
+    parameter SUM_TRUNCATION = 8,
     parameter NUM_ELEM = 7,
-    parameter CENTER_FREQ = 1,
-    parameter SUM_TRUNCATION = 8
+    parameter FILTER_VAL = 0,
+    parameter MAX_BITS = $clog2({BITS_PER_ELEM{1'b1}}*{BITS_PER_ELEM{1'b1}}*NUM_ELEM)
 ) (
     // Clock
     input wire clk,
+
+    // Reset
+    input wire rst,
 
     // signal to clock in data from inputs
     input wire i_start_calc,
@@ -25,60 +30,22 @@ module fir #(
 );
 
   reg [NUM_ELEM * BITS_PER_ELEM - 1:0] filter;
-  //TODO: refactor output from int32 to only allocate number of bits that will be used
-
-  // Find number of bits for full range
-  /* reg [$clog2({BITS_PER_ELEM{1'b1}}*NUM_ELEM):0] ; */
-  /* reg signed [$clog2({BITS_PER_ELEM{1'b1}}*NUM_ELEM):0] sum; */
-  // register for number of bits to right shift
-  // max possible product + max possible product ... for every element (i.e.
-  // NUM_ELEM times)
-  // TODO: calculate max bits from actual fir values instead of max, this may not be possible without using sv, or python and hardcoding it.
-  localparam MAX_BITS = $clog2({BITS_PER_ELEM{1'b1}}*{BITS_PER_ELEM{1'b1}}*NUM_ELEM);
-
   reg signed [MAX_BITS - 1:0] sum;
   reg signed [MAX_BITS - 1:0] working_sum;
-  /* reg signed [31:0] sum; */
-  /* reg signed [31:0] working_sum; */
 
-  function [7:0] trunc_32_to_8(input [31:0] int_32);
-    trunc_32_to_8 = int_32[7:0];
-  endfunction
-
-  // While Verilog 2005 doesn't support inline var
-  reg [$clog2(NUM_ELEM) + 1:0] j;
-  reg [$clog2(NUM_ELEM) + 1:0] i;
   initial begin
-    filter[BITS_PER_ELEM*(NUM_ELEM/2)+:BITS_PER_ELEM] =
-        trunc_32_to_8($rtoi({BITS_PER_ELEM{1'b1}} / 2));
-    // This section calculates wavelet coefficients for the filter bank
     // Ricker Equation: r(τ)=(1−1/2 * ω^2 * τ^2)exp(−1/4* ω^2 * τ^2),
-    //
-    //if odd, set the center value to be one times scaling factor, then
-    //truncated to 8 bits
-    if (NUM_ELEM % 2 == 1) begin
-      filter[NUM_ELEM/2] = trunc_32_to_8({BITS_PER_ELEM{1'b1}} / 2);
-    end
-
-    for (j = 1; j < (NUM_ELEM / 2 + 1); j = j + 1) begin
-      filter[BITS_PER_ELEM*((NUM_ELEM/2)+j)+:BITS_PER_ELEM] = trunc_32_to_8(
-          $rtoi(
-              {BITS_PER_ELEM{1'b1}} / 2 * (1.0 - 0.5 * $pow(
-                  `M_T * CENTER_FREQ, 2
-              ) * $pow(
-                  j * (1.0 / CENTER_FREQ) / (NUM_ELEM / 2 + 1.0), 2
-              )) * $exp(
-                  -0.25 * $pow(`M_T * CENTER_FREQ, 2) * $pow(j * (1.0/CENTER_FREQ) / (NUM_ELEM / 2 + 1.0), 2)
-              )
-          )
-      );
-      filter[BITS_PER_ELEM*((NUM_ELEM/2)-j)+:BITS_PER_ELEM] = filter[BITS_PER_ELEM*((NUM_ELEM/2)+j)+:BITS_PER_ELEM];
-    end
+    // see python code for calculations
+    filter = FILTER_VAL;
     sum = 0;
     working_sum = 0;
   end
 
   assign o_wavelet = sum[(MAX_BITS - 1): (MAX_BITS) - SUM_TRUNCATION]; // top 8 bits, (e.g. 31: 24 (32 - 8 = 24) )
+
+  // While verilog 2005 doesn't support inline var
+  reg [$clog2(NUM_ELEM) + 1:0] i;
+
 
   // we don't always want to have the sum be calculated for power reasons
   // (purpose of i_start_calc is to only perform calc when signalled) as
@@ -87,15 +54,22 @@ module fir #(
   // called "sum", and will maintian its value, only being updated if
   // i_start_calc is raised)
   always @(posedge clk) begin
-    if (i_start_calc) begin
-      working_sum = 0;
-      for (i = 0; i < NUM_ELEM; i = i + 1) begin
-        working_sum = working_sum + $signed(filter[BITS_PER_ELEM*i+:BITS_PER_ELEM]) * $signed(taps[BITS_PER_ELEM*i+:BITS_PER_ELEM]);
+    if (rst == 0) begin
+      // NOTE: parametric setting appears to require sv, so hardcoding with FILTER_VAL
+      filter <= FILTER_VAL;
+      sum <= 0;
+      working_sum <= 0;
+    end else begin
+      if (i_start_calc) begin
+        working_sum = 0;
+        for (i = 0; i < NUM_ELEM; i = i + 1) begin
+          working_sum = working_sum + $signed(filter[BITS_PER_ELEM*i+:BITS_PER_ELEM]) * $signed(taps[BITS_PER_ELEM*i+:BITS_PER_ELEM]);
+        end
+        sum <= working_sum;
       end
-      sum <= working_sum;
-    end
-    else begin
-      sum <= sum;
+      else begin
+        sum <= sum;
+      end
     end
   end
 

--- a/src/fir.v
+++ b/src/fir.v
@@ -54,7 +54,7 @@ module fir #(
   // called "sum", and will maintian its value, only being updated if
   // i_start_calc is raised)
   always @(posedge clk) begin
-    if (rst == 0) begin
+    if (rst) begin
       // NOTE: parametric setting appears to require sv, so hardcoding with FILTER_VAL
       filter <= FILTER_VAL;
       sum <= 0;

--- a/src/output_multiplexer.v
+++ b/src/output_multiplexer.v
@@ -31,7 +31,7 @@ module output_multiplexer #(
 
   always @(posedge clk) begin
     // TODO: is reset active low?
-    if (rst == 0) begin
+    if (rst) begin
       // TODO:convert this to parametric (currently hardcoded to 8 for the shuttle)
       multiplexer_out <= 8'b0;
     end else begin

--- a/src/output_multiplexer.v
+++ b/src/output_multiplexer.v
@@ -1,0 +1,54 @@
+`default_nettype none
+
+module output_multiplexer #(
+    parameter NUM_FILTERS = 8,
+    parameter SUM_TRUNCATION = 8
+) (
+    // Clock
+    input wire clk,
+
+    // Reset
+    input wire rst,
+
+    // truncated outputs from wavelets
+    input wire [(NUM_FILTERS*SUM_TRUNCATION - 1):0] i_truncated_wavelet_out,
+
+    // selection of output channels, hardcoded to 8 for now
+    input wire [7:0] i_select_output_channel,
+
+    // multiplexed output
+    output wire [SUM_TRUNCATION - 1:0] o_multiplexed_wavelet_out
+
+);
+
+  reg [7:0] multiplexer_out;
+
+  assign o_multiplexed_wavelet_out = multiplexer_out;
+
+  initial begin
+    multiplexer_out = 8'b0;
+  end
+
+  always @(posedge clk) begin
+    // TODO: is reset active low?
+    if (rst == 0) begin
+      // TODO:convert this to parametric (currently hardcoded to 8 for the shuttle)
+      multiplexer_out <= 8'b0;
+    end else begin
+      // TODO:convert this to parametric (currently hardcoded to 8 for the shuttle)
+        case (i_select_output_channel)
+          0: multiplexer_out <= i_truncated_wavelet_out[0*(SUM_TRUNCATION) +:SUM_TRUNCATION];
+          1: multiplexer_out <= i_truncated_wavelet_out[1*(SUM_TRUNCATION) +:SUM_TRUNCATION];
+          2: multiplexer_out <= i_truncated_wavelet_out[2*(SUM_TRUNCATION) +:SUM_TRUNCATION];
+          3: multiplexer_out <= i_truncated_wavelet_out[3*(SUM_TRUNCATION) +:SUM_TRUNCATION];
+          4: multiplexer_out <= i_truncated_wavelet_out[4*(SUM_TRUNCATION) +:SUM_TRUNCATION];
+          5: multiplexer_out <= i_truncated_wavelet_out[5*(SUM_TRUNCATION) +:SUM_TRUNCATION];
+          6: multiplexer_out <= i_truncated_wavelet_out[6*(SUM_TRUNCATION) +:SUM_TRUNCATION];
+          7: multiplexer_out <= i_truncated_wavelet_out[7*(SUM_TRUNCATION) +:SUM_TRUNCATION];
+          default: multiplexer_out <= i_truncated_wavelet_out[0+:SUM_TRUNCATION];
+        endcase
+    end
+  end
+
+
+endmodule

--- a/src/shift_register_line.v
+++ b/src/shift_register_line.v
@@ -8,6 +8,9 @@ module shift_register_line #(
     // Clock
     input wire clk,
 
+    // Reset
+    input wire rst,
+
     // Inputs Streaming
     input wire signed [BITS_PER_TAP - 1:0] i_value,
 
@@ -35,15 +38,23 @@ module shift_register_line #(
   end
 
   always @(posedge clk) begin
-    o_taps <= o_taps;
-    start_calc <= 0;
-    if (i_data_clk & ~data_clk_previous & ~data_clk_two_previous) begin //rising clk with one redundant reg to fix metastability
+    if (rst == 0) begin
+      o_taps <= 0;
+      stb <= 0;
+      start_calc <= 0;
+      data_clk_previous <= 0;
+      data_clk_two_previous <= 0;
+    end else begin
+      o_taps <= o_taps;
+      start_calc <= 0;
+      if (i_data_clk & ~data_clk_previous & ~data_clk_two_previous) begin //rising clk with one redundant reg to fix metastability
         o_taps <= {o_taps[((TOTAL_BITS-1)-BITS_PER_TAP):0], i_value};
         start_calc <= 1;
-    end
-    data_clk_previous <= i_data_clk;
-    data_clk_two_previous <= data_clk_previous;
+      end
+      data_clk_previous <= i_data_clk;
+      data_clk_two_previous <= data_clk_previous;
 
+    end
   end
 
   assign o_start_calc = start_calc;

--- a/src/shift_register_line.v
+++ b/src/shift_register_line.v
@@ -38,7 +38,7 @@ module shift_register_line #(
   end
 
   always @(posedge clk) begin
-    if (rst == 0) begin
+    if (rst) begin
       o_taps <= 0;
       stb <= 0;
       start_calc <= 0;

--- a/src/wavelet_transform.v
+++ b/src/wavelet_transform.v
@@ -23,8 +23,6 @@ module wavelet_transform #(
 
   wire start_calc;
 
-  parameter COUNTER_WIDTH = 4;
-
   `ifdef COCOTB_SIM
     initial begin
       $dumpfile ("wavelet_transform.vcd");

--- a/src/wavelet_transform.v
+++ b/src/wavelet_transform.v
@@ -25,37 +25,40 @@ module wavelet_transform #(
     // 8 bit output, channel selected by multiplexer
     output wire [SUM_TRUNCATION - 1:0] o_multiplexed_wavelet_out,
 
+    // chip active gpio signal
+    output wire o_active,
+
     // set the multiplexed wavelet out pins as outputs
-    output [7:0] io_oeb
+    output [8:0] io_oeb
 
 );
-// From Python Ricker-Wavelet Generator:
-// taps approx_bits_needed filter_values
-// 3 15 c77fc7
-// 5 15 e4dd7fdde4 // NOTE: using 5 instead of 6 for waveform capture
-// 8 15 fde9c71212c7e9fd // NOTE: 8 replaced w/9 taps (better waveform capture)
-// 9 16 73'hFEEAC8127F12C8EAFE
-// 15 17 fef7e7cfc9f9507f50f9c9cfe7f7fe
-// 26 17 00fefcf8f0e4d5c9c9dd073e6c6c3e07ddc9c9d5e4f0f8fcfe00
-// 46 18 000000fefdfbf8f3ede6ded5cdc8c7cddaef0b2b4b667878664b2b0befdacdc7c8cdd5dee6edf3f8fbfdfe000000
-// 80 19 0000000000fefefdfcfbf9f7f5f2efebe7e2ddd8d3cecac8c7c8cbd1dae5f30315283b4d5d6b767c7c766b5d4d3b281503f3e5dad1cbc8c7c8caced3d8dde2e7ebeff2f5f7f9fbfcfdfefe0000000000
-// 140 20 000000000000000000fefefefdfdfcfcfbfaf9f8f7f6f4f3f1efedeae8e5e2dfdddad7d4d1cecccac8c7c7c7c8c9cccfd3d9dfe6edf60009141e29343f4a535d656d73787c7e7e7c78736d655d534a3f34291e140900f6ede6dfd9d3cfccc9c8c7c7c7c8caccced1d4d7dadddfe2e5e8eaedeff1f3f4f6f7f8f9fafbfcfcfdfdfefefe000000000000000000
- /* 3 15 c77fc7 */
-/* 6 14 fbd5efefd5fb */
-/* 9 16 f9dfc81f7f1fc8dff9 */
-/* 16 16 00fcf3e1cbcd01555501cdcbe1f3fc00 */
-/* 27 17 00fefbf6ede0d2c8cbe10c416d7f6d410ce1cbc8d2e0edf6fbfe00 */
-/* 47 18 0000fefdfcfaf6f2ebe4dcd3ccc7c8cfddf30e2e4d67787f78674d2e0ef3ddcfc8c7ccd3dce4ebf2f6fafcfdfe0000 */
-/* 81 19 00000000fefefdfdfcfaf9f7f4f1eeeae5e0dbd6d2cdcac7c7c8ccd2dbe7f505172a3c4e5e6c767c7f7c766c5e4e3c2a1705f5e7dbd2ccc8c7c7cacdd2d6dbe0e5eaeef1f4f7f9fafcfdfdfefe00000000 */
-/* 141 20 0000000000000000fefefefefdfdfcfcfbfaf9f8f7f5f4f2f0eeeceae7e4e2dfdcd9d6d3d0cecccac8c7c7c7c8caccd0d4d9e0e7eef7000a151f2a35404a545d666d73787c7e7f7e7c78736d665d544a40352a1f150a00f7eee7e0d9d4d0cccac8c7c7c7c8caccced0d3d6d9dcdfe2e4e7eaeceef0f2f4f5f7f8f9fafbfcfcfdfdfefefefe0000000000000000 */
 
+  // From Python Ricker-Wavelet Generator:
+  // taps approx_bits_needed filter_values
+  // 3 15 c77fc7
+  // 5 15 e4dd7fdde4 // NOTE: using 5 instead of 6 for waveform capture
+  // 8 15 fde9c71212c7e9fd // NOTE: 8 replaced w/9 taps (better waveform capture)
+  // 9 16 73'hFEEAC8127F12C8EAFE
+  // 15 17 fef7e7cfc9f9507f50f9c9cfe7f7fe
+  // 26 17 00fefcf8f0e4d5c9c9dd073e6c6c3e07ddc9c9d5e4f0f8fcfe00
+  // 46 18 000000fefdfbf8f3ede6ded5cdc8c7cddaef0b2b4b667878664b2b0befdacdc7c8cdd5dee6edf3f8fbfdfe000000
+  // 80 19 0000000000fefefdfcfbf9f7f5f2efebe7e2ddd8d3cecac8c7c8cbd1dae5f30315283b4d5d6b767c7c766b5d4d3b281503f3e5dad1cbc8c7c8caced3d8dde2e7ebeff2f5f7f9fbfcfdfefe0000000000
+  // 140 20 000000000000000000fefefefdfdfcfcfbfaf9f8f7f6f4f3f1efedeae8e5e2dfdddad7d4d1cecccac8c7c7c7c8c9cccfd3d9dfe6edf60009141e29343f4a535d656d73787c7e7e7c78736d655d534a3f34291e140900f6ede6dfd9d3cfccc9c8c7c7c7c8caccced1d4d7dadddfe2e5e8eaedeff1f3f4f6f7f8f9fafbfcfcfdfdfefefe000000000000000000
 
+  /* 3 15 c77fc7 */
+  /* 6 14 fbd5efefd5fb */
+  /* 9 16 f9dfc81f7f1fc8dff9 */
+  /* 16 16 00fcf3e1cbcd01555501cdcbe1f3fc00 */
+  /* 27 17 00fefbf6ede0d2c8cbe10c416d7f6d410ce1cbc8d2e0edf6fbfe00 */
+  /* 47 18 0000fefdfcfaf6f2ebe4dcd3ccc7c8cfddf30e2e4d67787f78674d2e0ef3ddcfc8c7ccd3dce4ebf2f6fafcfdfe0000 */
+  /* 81 19 00000000fefefdfdfcfaf9f7f4f1eeeae5e0dbd6d2cdcac7c7c8ccd2dbe7f505172a3c4e5e6c767c7f7c766c5e4e3c2a1705f5e7dbd2ccc8c7c7cacdd2d6dbe0e5eaeef1f4f7f9fafcfdfdfefe00000000 */
+  /* 141 20 0000000000000000fefefefefdfdfcfcfbfaf9f8f7f5f4f2f0eeeceae7e4e2dfdcd9d6d3d0cecccac8c7c7c7c8caccd0d4d9e0e7eef7000a151f2a35404a545d666d73787c7e7f7e7c78736d665d544a40352a1f150a00f7eee7e0d9d4d0cccac8c7c7c7c8caccced0d3d6d9dcdfe2e4e7eaeceef0f2f4f5f7f8f9fafbfcfcfdfdfefefefe0000000000000000 */
 
   // output bits
   wire [(TOTAL_FILTERS*SUM_TRUNCATION - 1):0] truncated_wavelet_out;
 
-  // set the multiplexed wavelet out pins as outputs
-  assign io_oeb = 8'h00;
+  // set the multiplexed wavelet out pins as outputs, as well as active signal pin
+  assign io_oeb = 9'b0_0000_0000;
 
   wire start_calc;
 
@@ -80,6 +83,18 @@ module wavelet_transform #(
   parameter TOTAL_BITS = BITS_PER_TAP * TOTAL_TAPS;
 
   wire [TOTAL_BITS - 1:0] taps;
+
+  reg active;
+  assign o_active = active;
+
+  // NOTE: signal that this module is active after pulling out of reset
+  always @(posedge clk) begin
+    if (rst == 0) begin
+      active <= 1'b0;
+    end else begin
+      active <= 1'b1;
+    end
+  end
 
   output_multiplexer #(
       .NUM_FILTERS(NUM_FILTERS),
@@ -207,7 +222,6 @@ module wavelet_transform #(
       .i_start_calc(start_calc)
     );
 
-
     fir #(
       .BITS_PER_ELEM(BITS_PER_ELEM),
       .SUM_TRUNCATION(SUM_TRUNCATION),
@@ -222,5 +236,5 @@ module wavelet_transform #(
       .i_start_calc(start_calc)
     );
 
-  // TODO: add formal section
+    // TODO: add formal section
 endmodule

--- a/src/wavelet_transform.v
+++ b/src/wavelet_transform.v
@@ -89,7 +89,7 @@ module wavelet_transform #(
 
   // NOTE: signal that this module is active after pulling out of reset
   always @(posedge clk) begin
-    if (rst == 0) begin
+    if (rst) begin
       active <= 1'b0;
     end else begin
       active <= 1'b1;

--- a/src/wavelet_transform.v
+++ b/src/wavelet_transform.v
@@ -7,6 +7,11 @@ module wavelet_transform #(
     parameter TOTAL_FILTERS = 8,
     parameter SUM_TRUNCATION = 8
 ) (
+`ifdef USE_POWER_PINS
+	inout vccd1,	// User area 1 1.8V power
+	inout vssd1,	// User area 1 digital ground
+`endif
+
     // Clock
     input wire clk,
 

--- a/src/wavelet_transform.v
+++ b/src/wavelet_transform.v
@@ -4,7 +4,7 @@
 
 module wavelet_transform #(
     parameter BITS_PER_ELEM = 8,
-    parameter TOTAL_FILTERS = 4,
+    parameter TOTAL_FILTERS = 8,
     parameter SUM_TRUNCATION = 8
 ) (
     // Clock
@@ -16,11 +16,35 @@ module wavelet_transform #(
     // data_input clock (rising edge)
     input wire i_data_clk,
 
-    // output bits, (for now all 32 bit signed registers)
-    output wire [(TOTAL_FILTERS*SUM_TRUNCATION - 1):0] o_truncated_wavelet_out
+    // TODO: implement reset
+    input wire rst,
+
+    // multiplexing for output channels
+    input wire [7:0] i_select_output_channel,
+
+    // 8 bit output, channel selected by multiplexer
+    output wire [SUM_TRUNCATION - 1:0] o_multiplexed_wavelet_out,
+
+    // set these as outputs
+    output [7:0] io_oeb
 
 );
+// From python ricker wavelet generator
+// 3 15 c77fc7
+// 5 15 e4dd7fdde4
+// 8 15 fde9c71212c7e9fd
+// 15 17 fef7e7cfc9f9507f50f9c9cfe7f7fe
+// 26 17 00fefcf8f0e4d5c9c9dd073e6c6c3e07ddc9c9d5e4f0f8fcfe00
+// 46 18 000000fefdfbf8f3ede6ded5cdc8c7cddaef0b2b4b667878664b2b0befdacdc7c8cdd5dee6edf3f8fbfdfe000000
+// 80 19 0000000000fefefdfcfbf9f7f5f2efebe7e2ddd8d3cecac8c7c8cbd1dae5f30315283b4d5d6b767c7c766b5d4d3b281503f3e5dad1cbc8c7c8caced3d8dde2e7ebeff2f5f7f9fbfcfdfefe0000000000
+// 140 20 000000000000000000fefefefdfdfcfcfbfaf9f8f7f6f4f3f1efedeae8e5e2dfdddad7d4d1cecccac8c7c7c7c8c9cccfd3d9dfe6edf60009141e29343f4a535d656d73787c7e7e7c78736d655d534a3f34291e140900f6ede6dfd9d3cfccc9c8c7c7c7c8caccced1d4d7dadddfe2e5e8eaedeff1f3f4f6f7f8f9fafbfcfcfdfdfefefe000000000000000000
 
+
+  // output bits
+  wire [(TOTAL_FILTERS*SUM_TRUNCATION - 1):0] truncated_wavelet_out;
+
+  // low of outputs
+  assign io_oeb = 8'b0;
   wire start_calc;
 
   `ifdef COCOTB_SIM
@@ -34,16 +58,27 @@ module wavelet_transform #(
   parameter BASE_FREQ = 1;
   parameter BASE_NUM_ELEM = 3;
   parameter NUM_FILTERS = TOTAL_FILTERS;
-  /* parameter BITS_PER_ELEM = 8; */
   // number of elements is ∝ HIGHEST_FREQ/THIS_FREQ
   // really we should calculate the ratio of the elements to produce the freq
   // NUM_ELEM * ELEM_RATIO
-  parameter TOTAL_TAPS = (1 + $rtoi(BASE_NUM_ELEM * 1.0 / $pow(`ELEM_RATIO, NUM_FILTERS - 1)));
+  /* parameter TOTAL_TAPS = (1 + $rtoi(BASE_NUM_ELEM * 1.0 / $pow(`ELEM_RATIO, NUM_FILTERS - 1))); */
+  parameter TOTAL_TAPS = 1120; // for 8 filters starting at 3 elements
   parameter BITS_PER_TAP = BITS_PER_ELEM;
 
   parameter TOTAL_BITS = BITS_PER_TAP * TOTAL_TAPS;
 
   wire [TOTAL_BITS - 1:0] taps;
+
+  output_multiplexer #(
+      .NUM_FILTERS(NUM_FILTERS),
+      .SUM_TRUNCATION(SUM_TRUNCATION)
+  ) om_1 (
+      .clk(clk),
+      .rst(rst),
+      .i_truncated_wavelet_out(truncated_wavelet_out),
+      .i_select_output_channel(i_select_output_channel),
+      .o_multiplexed_wavelet_out(o_multiplexed_wavelet_out)
+  );
 
   shift_register_line #(
       .TOTAL_TAPS(TOTAL_TAPS),
@@ -51,41 +86,128 @@ module wavelet_transform #(
       .TOTAL_BITS(TOTAL_BITS)
   ) srl_1 (
       .clk  (clk),
+      .rst(rst),
       .i_value(i_value),
-      .o_taps (taps[TOTAL_BITS-1:0]),
       .i_data_clk (i_data_clk),
-      .o_start_calc (start_calc)
-  );
+      .o_start_calc (start_calc),
+      .o_taps (taps[TOTAL_BITS-1:0])
+    );
 
-  genvar i;
+    // taps is the number of bits in the filter
+    fir #(
+      .BITS_PER_ELEM(BITS_PER_ELEM),
+      .SUM_TRUNCATION(SUM_TRUNCATION),
+      .NUM_ELEM(3),
+      .FILTER_VAL(24'hC77FC7),
+      .MAX_BITS(16)
+    ) fir_0 (
+      .clk(clk),
+      .rst(rst),
+      .taps (taps[(BITS_PER_ELEM*3) - 1:0]),
+      .o_wavelet(truncated_wavelet_out[7:0]),
+      .i_start_calc(start_calc)
+    );
 
-  generate
-    for (i = 0; i < NUM_FILTERS; i = i + 1) begin
-      if ($rtoi(BASE_NUM_ELEM * 1 / $pow(`ELEM_RATIO, i)) % 2 == 1) begin
-        fir #(
-            .BITS_PER_ELEM(BITS_PER_ELEM),
-            .NUM_ELEM($rtoi(BASE_NUM_ELEM * 1.0 / $pow(`ELEM_RATIO, i))),
-            .CENTER_FREQ(BASE_FREQ * $rtoi(BASE_NUM_ELEM * 1.0 / $pow(`ELEM_RATIO, i)))
-        ) fir_1 (
-            .clk(clk),
-            .taps (taps[BITS_PER_ELEM*$rtoi(BASE_NUM_ELEM*1.0/$pow(`ELEM_RATIO, i))-1:0]),
-            .o_wavelet(o_truncated_wavelet_out[SUM_TRUNCATION*i+:SUM_TRUNCATION]),
-            .i_start_calc(start_calc)
-        );
-      end else begin
-        fir #(
-            .BITS_PER_ELEM(BITS_PER_ELEM),
-            .NUM_ELEM(1 + $rtoi(BASE_NUM_ELEM * 1.0 / $pow(`ELEM_RATIO, i))),
-            .CENTER_FREQ(BASE_FREQ * $rtoi(BASE_NUM_ELEM * 1.0 / $pow(`ELEM_RATIO, i)))
-        ) fir_1 (
-            .clk(clk),
-            .taps (taps[BITS_PER_ELEM*(1+$rtoi(BASE_NUM_ELEM*1.0/$pow(`ELEM_RATIO, i)))-1:0]),
-            .o_wavelet(o_truncated_wavelet_out[SUM_TRUNCATION*i+:SUM_TRUNCATION]),
-            .i_start_calc(start_calc)
-        );
-      end
-    end
-  endgenerate
+    fir #(
+      .BITS_PER_ELEM(BITS_PER_ELEM),
+      .SUM_TRUNCATION(SUM_TRUNCATION),
+      .NUM_ELEM(5),
+      .FILTER_VAL(40'hE4DD7FDDE4),
+      .MAX_BITS(16)
+    ) fir_1 (
+      .clk(clk),
+      .rst(rst),
+      .taps (taps[(BITS_PER_ELEM*5) - 1:0]),
+      .o_wavelet(truncated_wavelet_out[15:8]),
+      .i_start_calc(start_calc)
+    );
+
+    // NOTE: using 9 instead of 8 elem, as the 9-taps capture the waveform better than 8
+    /* .FILTER_VAL(64'hFDE9C71212C7E9FD), */
+    fir #(
+      .BITS_PER_ELEM(BITS_PER_ELEM),
+      .SUM_TRUNCATION(SUM_TRUNCATION),
+      .NUM_ELEM(9),
+      .FILTER_VAL(73'hFEEAC8127F12C8EAFE),
+      .MAX_BITS(16)
+    ) fir_2 (
+      .clk(clk),
+      .rst(rst),
+      .taps (taps[(BITS_PER_ELEM*9) - 1:0]),
+      .o_wavelet(truncated_wavelet_out[23:16]),
+      .i_start_calc(start_calc)
+    );
+
+    fir #(
+      .BITS_PER_ELEM(BITS_PER_ELEM),
+      .SUM_TRUNCATION(SUM_TRUNCATION),
+      .NUM_ELEM(15),
+      .FILTER_VAL(120'hFEF7E7CFC9F9507F50F9C9CFE7F7FE),
+      .MAX_BITS(18)
+    ) fir_3 (
+      .clk(clk),
+      .rst(rst),
+      .taps (taps[(BITS_PER_ELEM*15) - 1:0]),
+      .o_wavelet(truncated_wavelet_out[31:24]),
+      .i_start_calc(start_calc)
+    );
+
+    fir #(
+      .BITS_PER_ELEM(BITS_PER_ELEM),
+      .SUM_TRUNCATION(SUM_TRUNCATION),
+      .NUM_ELEM(26),
+      .FILTER_VAL(208'h00FEFCF8F0E4D5C9C9DD073E6C6C3E07DDC9C9D5E4F0F8FCFE00),
+      .MAX_BITS(18)
+    ) fir_4 (
+      .clk(clk),
+      .rst(rst),
+      .taps (taps[(BITS_PER_ELEM*26) - 1:0]),
+      .o_wavelet(truncated_wavelet_out[39:32]),
+      .i_start_calc(start_calc)
+    );
+
+    fir #(
+      .BITS_PER_ELEM(BITS_PER_ELEM),
+      .SUM_TRUNCATION(SUM_TRUNCATION),
+      .NUM_ELEM(46),
+      .FILTER_VAL(368'h000000FEFDFBF8F3EDE6DED5CDC8C7CDDAEF0B2B4B667878664B2B0BEFDACDC7C8CDD5DEE6EDF3F8FBFDFE000000),
+      .MAX_BITS(19)
+    ) fir_5 (
+      .clk(clk),
+      .rst(rst),
+      .taps (taps[(BITS_PER_ELEM*46) - 1:0]),
+      .o_wavelet(truncated_wavelet_out[47:40]),
+      .i_start_calc(start_calc)
+    );
+
+    fir #(
+      .BITS_PER_ELEM(BITS_PER_ELEM),
+      .SUM_TRUNCATION(SUM_TRUNCATION),
+      .NUM_ELEM(80),
+      .FILTER_VAL(640'h0000000000FEFEFDFCFBF9F7F5F2EFEBE7E2DDD8D3CECAC8C7C8CBD1DAE5F30315283B4D5D6B767C7C766B5D4D3B281503F3E5DAD1CBC8C7C8CACED3D8DDE2E7EBEFF2F5F7F9FBFCFDFEFE0000000000),
+      .MAX_BITS(20)
+    ) fir_6 (
+      .clk(clk),
+      .rst(rst),
+      .taps (taps[(BITS_PER_ELEM*80) - 1:0]),
+      .o_wavelet(truncated_wavelet_out[55:48]),
+      .i_start_calc(start_calc)
+    );
+
+
+    fir #(
+      .BITS_PER_ELEM(BITS_PER_ELEM),
+      .SUM_TRUNCATION(SUM_TRUNCATION),
+      .NUM_ELEM(140),
+      .FILTER_VAL(1120'h000000000000000000FEFEFEFDFDFCFCFBFAF9F8F7F6F4F3F1EFEDEAE8E5E2DFDDDAD7D4D1CECCCAC8C7C7C7C8C9CCCFD3D9DFE6EDF60009141E29343F4A535D656D73787C7E7E7C78736D655D534A3F34291E140900F6EDE6DFD9D3CFCCC9C8C7C7C7C8CACCCED1D4D7DADDDFE2E5E8EAEDEFF1F3F4F6F7F8F9FAFBFCFCFDFDFEFEFE000000000000000000),
+      .MAX_BITS(20)
+    ) fir_7 (
+      .clk(clk),
+      .rst(rst),
+      .taps (taps[(BITS_PER_ELEM*140) - 1:0]),
+      .o_wavelet(truncated_wavelet_out[63:56]),
+      .i_start_calc(start_calc)
+    );
 
   // TODO: add formal section
 endmodule

--- a/test/test_cwt.py
+++ b/test/test_cwt.py
@@ -25,6 +25,10 @@ async def test(dut):
 
     dut.i_data_clk.value = 0
     counter = 0
+    dut.i_select_output_channel = 0
+    channel_select = 0
+    channel_select_counter = 200
+
 
     # process audio through dut
     for i in range(nframes):
@@ -32,6 +36,13 @@ async def test(dut):
         frame = audio_in.readframes(1)
         # print(frame)
         (val,) = struct.unpack("h", frame)
+
+        if channel_select_counter == 0:
+            channel_select += 1
+            dut.i_select_output_channel = channel_select % 8
+            channel_select_counter = 200
+        else:
+            channel_select_counter -= 1
 
         dut.i_value.value = int(math.sin(0.1*counter*(1 + 0.01*counter))  * 127)
         counter = 1 +counter

--- a/test/test_cwt.py
+++ b/test/test_cwt.py
@@ -25,7 +25,7 @@ async def test(dut):
 
     dut.i_data_clk.value = 0
     counter = 0
-    dut.i_select_output_channel = 0
+    dut.i_select_output_channel = 0 % 8
     channel_select = 0
     channel_select_counter = 200
 
@@ -45,7 +45,7 @@ async def test(dut):
             channel_select_counter -= 1
 
         dut.i_value.value = int(math.sin(0.1*counter*(1 + 0.01*counter))  * 127)
-        counter = 1 +counter
+        counter = 1 + counter
         # print(dut.i_value.value)
         # if val > 0:
         #     dut.i_value.value = min(int((val / 32768.0 * 127)), 127)

--- a/wavelet.gtkw
+++ b/wavelet.gtkw
@@ -1,22 +1,34 @@
 [*]
 [*] GTKWave Analyzer v3.3.111 (w)1999-2020 BSI
-[*] Thu Jun  2 01:51:55 2022
+[*] Thu Jun  2 10:11:45 2022
 [*]
 [dumpfile] "/home/zerotoasic/asic_tools/caravel_user_project/verilog/rtl/wavelet_transform/wavelet_transform.vcd"
-[dumpfile_mtime] "Thu Jun  2 01:44:44 2022"
-[dumpfile_size] 799157586
+[dumpfile_mtime] "Thu Jun  2 10:02:36 2022"
+[dumpfile_size] 799415388
 [savefile] "/home/zerotoasic/asic_tools/caravel_user_project/verilog/rtl/wavelet_transform/wavelet.gtkw"
-[timestart] 33800000
-[size] 1848 1022
-[pos] -51 -51
-*-24.900000 123610000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[timestart] 45500000
+[size] 924 1022
+[pos] 873 -51
+*-26.700001 129220000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
 [treeopen] wavelet_transform.
 [sst_width] 297
-[signals_width] 389
+[signals_width] 412
 [sst_expanded] 1
 [sst_vpaned_height] 304
-@8420
+@c08420
 wavelet_transform.fir_0.o_wavelet[7:0]
+@28
+(0)wavelet_transform.fir_0.o_wavelet[7:0]
+(1)wavelet_transform.fir_0.o_wavelet[7:0]
+(2)wavelet_transform.fir_0.o_wavelet[7:0]
+(3)wavelet_transform.fir_0.o_wavelet[7:0]
+(4)wavelet_transform.fir_0.o_wavelet[7:0]
+(5)wavelet_transform.fir_0.o_wavelet[7:0]
+(6)wavelet_transform.fir_0.o_wavelet[7:0]
+(7)wavelet_transform.fir_0.o_wavelet[7:0]
+@1409600
+-group_end
+@8420
 wavelet_transform.fir_1.o_wavelet[7:0]
 wavelet_transform.fir_2.o_wavelet[7:0]
 wavelet_transform.fir_3.o_wavelet[7:0]
@@ -24,16 +36,12 @@ wavelet_transform.fir_4.o_wavelet[7:0]
 wavelet_transform.fir_5.o_wavelet[7:0]
 wavelet_transform.fir_6.o_wavelet[7:0]
 wavelet_transform.fir_7.o_wavelet[7:0]
-wavelet_transform.i_value[7:0]
-wavelet_transform.o_multiplexed_wavelet_out[7:0]
+wavelet_transform.srl_1.i_value[7:0]
+@200
+-
 @22
-wavelet_transform.fir_0.taps[23:0]
-wavelet_transform.fir_1.taps[39:0]
-wavelet_transform.fir_1.i[4:0]
-wavelet_transform.fir_1.filter[39:0]
-@23
-wavelet_transform.fir_1.working_sum[15:0]
-@22
-wavelet_transform.i_select_output_channel[7:0]
+wavelet_transform.om_1.i_select_output_channel[7:0]
+@8420
+wavelet_transform.om_1.o_multiplexed_wavelet_out[7:0]
 [pattern_trace] 1
 [pattern_trace] 0

--- a/wavelet.gtkw
+++ b/wavelet.gtkw
@@ -1,46 +1,39 @@
 [*]
 [*] GTKWave Analyzer v3.3.111 (w)1999-2020 BSI
-[*] Wed Jun  1 00:08:31 2022
+[*] Thu Jun  2 01:51:55 2022
 [*]
-[dumpfile] "/home/zerotoasic/OpensourceWaveletTransform/wavelet_transform.vcd"
-[dumpfile_mtime] "Wed Jun  1 00:03:01 2022"
-[dumpfile_size] 35954736
-[savefile] "/home/zerotoasic/OpensourceWaveletTransform/wavelet.gtkw"
-[timestart] 1222100
+[dumpfile] "/home/zerotoasic/asic_tools/caravel_user_project/verilog/rtl/wavelet_transform/wavelet_transform.vcd"
+[dumpfile_mtime] "Thu Jun  2 01:44:44 2022"
+[dumpfile_size] 799157586
+[savefile] "/home/zerotoasic/asic_tools/caravel_user_project/verilog/rtl/wavelet_transform/wavelet.gtkw"
+[timestart] 33800000
 [size] 1848 1022
-[pos] 51 45
-*-16.199999 184460000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[pos] -51 -51
+*-24.900000 123610000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
 [treeopen] wavelet_transform.
-[treeopen] wavelet_transform.genblk1[0].
-[treeopen] wavelet_transform.genblk1[0].genblk1.
-[treeopen] wavelet_transform.genblk1[1].
-[treeopen] wavelet_transform.genblk1[1].genblk1.
-[treeopen] wavelet_transform.genblk1[2].
-[treeopen] wavelet_transform.genblk1[2].genblk1.
-[treeopen] wavelet_transform.genblk1[3].
-[treeopen] wavelet_transform.genblk1[3].genblk1.
 [sst_width] 297
-[signals_width] 222
-[sst_expanded] 0
-[sst_vpaned_height] 271
-@20000
--
+[signals_width] 389
+[sst_expanded] 1
+[sst_vpaned_height] 304
 @8420
+wavelet_transform.fir_0.o_wavelet[7:0]
+wavelet_transform.fir_1.o_wavelet[7:0]
+wavelet_transform.fir_2.o_wavelet[7:0]
+wavelet_transform.fir_3.o_wavelet[7:0]
+wavelet_transform.fir_4.o_wavelet[7:0]
+wavelet_transform.fir_5.o_wavelet[7:0]
+wavelet_transform.fir_6.o_wavelet[7:0]
+wavelet_transform.fir_7.o_wavelet[7:0]
 wavelet_transform.i_value[7:0]
-wavelet_transform.genblk1[0].genblk1.fir_1.o_wavelet[7:0]
-wavelet_transform.genblk1[1].genblk1.fir_1.o_wavelet[7:0]
-wavelet_transform.genblk1[2].genblk1.fir_1.o_wavelet[7:0]
-@8421
-wavelet_transform.genblk1[3].genblk1.fir_1.o_wavelet[7:0]
-@200
--
-@28
-wavelet_transform.srl_1.data_clk_two_previous
-wavelet_transform.srl_1.data_clk_previous
-[color] 1
-wavelet_transform.srl_1.i_data_clk
+wavelet_transform.o_multiplexed_wavelet_out[7:0]
 @22
-wavelet_transform.i_value[7:0]
-wavelet_transform.srl_1.o_taps[127:0]
+wavelet_transform.fir_0.taps[23:0]
+wavelet_transform.fir_1.taps[39:0]
+wavelet_transform.fir_1.i[4:0]
+wavelet_transform.fir_1.filter[39:0]
+@23
+wavelet_transform.fir_1.working_sum[15:0]
+@22
+wavelet_transform.i_select_output_channel[7:0]
 [pattern_trace] 1
 [pattern_trace] 0

--- a/wavelet.gtkw
+++ b/wavelet.gtkw
@@ -1,15 +1,15 @@
 [*]
 [*] GTKWave Analyzer v3.3.111 (w)1999-2020 BSI
-[*] Thu Jun  2 10:11:45 2022
+[*] Thu Jun  2 21:40:13 2022
 [*]
 [dumpfile] "/home/zerotoasic/asic_tools/caravel_user_project/verilog/rtl/wavelet_transform/wavelet_transform.vcd"
-[dumpfile_mtime] "Thu Jun  2 10:02:36 2022"
-[dumpfile_size] 799415388
+[dumpfile_mtime] "Thu Jun  2 21:38:08 2022"
+[dumpfile_size] 799195551
 [savefile] "/home/zerotoasic/asic_tools/caravel_user_project/verilog/rtl/wavelet_transform/wavelet.gtkw"
-[timestart] 45500000
-[size] 924 1022
-[pos] 873 -51
-*-26.700001 129220000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
+[timestart] 0
+[size] 1848 1022
+[pos] 72 0
+*-27.300001 129220000 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1 -1
 [treeopen] wavelet_transform.
 [sst_width] 297
 [signals_width] 412
@@ -26,7 +26,7 @@ wavelet_transform.fir_0.o_wavelet[7:0]
 (5)wavelet_transform.fir_0.o_wavelet[7:0]
 (6)wavelet_transform.fir_0.o_wavelet[7:0]
 (7)wavelet_transform.fir_0.o_wavelet[7:0]
-@1409600
+@1401200
 -group_end
 @8420
 wavelet_transform.fir_1.o_wavelet[7:0]
@@ -43,5 +43,7 @@ wavelet_transform.srl_1.i_value[7:0]
 wavelet_transform.om_1.i_select_output_channel[7:0]
 @8420
 wavelet_transform.om_1.o_multiplexed_wavelet_out[7:0]
+@28
+wavelet_transform.o_active
 [pattern_trace] 1
 [pattern_trace] 0


### PR DESCRIPTION
Remove auto generators, using instead mainly the CWT.py python script for generation of coefficients.

This had the advantage that verilog cannot synthesize loop variables, etc (something required due to non-sv, verilog quirks).